### PR TITLE
fix: ipfs.name.resolve returns an async iterable instead of a promise

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6151,6 +6151,11 @@
         "handlebars": "^4.1.2"
       }
     },
+    "it-last": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.2.tgz",
+      "integrity": "sha512-zjWiVvkDXKxGA+u2ZNzq321RWnj52RLucsIX0Bve3NUX3X/b1RjtUufvUdjtkFtQLKG1yCf5+hxbdeIYiRT1rQ=="
+    },
     "jest": {
       "version": "24.8.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-24.8.0.tgz",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
   },
   "dependencies": {
     "buffer": "^5.2.1",
+    "it-last": "^1.0.2",
     "libp2p-crypto": "^0.16.1",
     "lodash": "^4.17.11",
     "peer-id": "^0.12.2",

--- a/src/__tests__/mocks/index.js
+++ b/src/__tests__/mocks/index.js
@@ -44,10 +44,14 @@ export const createMockIpfs = () => {
         keychainKeys.push({ name: keyName });
     };
 
+    async function* resolveMock() {
+        yield mockPath;
+    }
+
     return {
         isOnline: jest.fn(() => true),
         name: {
-            resolve: jest.fn(async () => ({ path: mockPath })),
+            resolve: jest.fn(resolveMock),
             publish: jest.fn(async () => {}),
         },
         dag: {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import createDocument, { assertDocument } from './document';
 import { generateRandomString, generateDid, parseDid, pemToBuffer } from './utils';
 import { UnavailableIpfs, InvalidDid, IllegalCreate } from './utils/errors';
+import last from 'it-last';
 
 class Ipid {
     #ipfs;
@@ -15,7 +16,7 @@ class Ipid {
         const { identifier } = parseDid(did);
 
         try {
-            const { path } = await this.#ipfs.name.resolve(identifier);
+            const path = await last(this.#ipfs.name.resolve(identifier));
             const cidStr = path.replace(/^\/ipfs\//, '');
             const { value: content } = await this.#ipfs.dag.get(cidStr);
 


### PR DESCRIPTION
The signature of `ipfs.name.resolve` changed during the migration of js-ipfs from streams to async iterables 

* https://gist.github.com/alanshaw/04b2ddc35a6fff25c040c011ac6acf26#file-migration-md.
* https://github.com/ipfs/js-ipfs/blob/master/docs/core-api/NAME.md#ipfsnameresolvevalue-options

This PR fixes the API use. It should also fix #22 

I have tried this out locally with my code as well and I was able to resolve documents successfully. I could provide a more thorough end to end test if you like.